### PR TITLE
Add troubleshooting guidance for split APK installation issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ sudo echo foobar | apksigner sign --ks ./patched_instagram_key.jks --v1-signing-
 - now **Uninstall your current instagram**
 - copy `install.apk` to your phone and install it
 
+**Note for newer versions**: Newer Android apps use split APKs (e.g. version 408.0.0.51.78 contains `base.apk` and `split_config.xxhdpi.apk`). Follow the guide above for `base.apk`, then additionally sign the split config:
+```
+echo foobar | apksigner sign --ks patched_instagram_key.jks split_config.xxhdpi.apk
+```
+Install both using:
+```
+adb install-multiple install.apk split_config.xxhdpi.apk
+```
+
 # 🛠️ Contribution Guidelines
 
 ## 🚀 Best Practices

--- a/TROUBLESHOOT.md
+++ b/TROUBLESHOOT.md
@@ -1,5 +1,12 @@
 # Troubleshooting (Problemi comuni)
 Commons problems and solutions 💡
+## APK won't install - Missing split error
+If installation fails via `adb install` with:
+```
+adb: failed to install base.apk: Failure [INSTALL_FAILED_MISSING_SPLIT: Missing split for com.instagram.android]
+```
+Or Android shows "Can't install app" when installing manually, this happens with newer Instagram versions that use split APKs. You need to sign **both** `base.apk` (renamed to `install.apk` if you follow the [README instructions](README.md#build-your-own-apk)) and the split config file (e.g., `split_config.xxhdpi.apk`), then install them together. See the [note for newer versions](README.md#build-your-own-apk) in the build guide.
+
 ## Disable Meta App installer & Meta App Manager problem
 <img src="https://github.com/user-attachments/assets/40eab206-dfcc-44dd-b8f6-03d97f4e7798" width="200" />
 


### PR DESCRIPTION
Added documentation for handling split APK installations in newer Instagram versions (e.g., 408.0.0.51.78).

Tested with IG version: `408.0.0.51.78`